### PR TITLE
Use a Reader, to support 1.12

### DIFF
--- a/src/com/mythicacraft/voteroulette/utils/ConfigAccessor.java
+++ b/src/com/mythicacraft/voteroulette/utils/ConfigAccessor.java
@@ -3,6 +3,8 @@ package com.mythicacraft.voteroulette.utils;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
@@ -26,14 +28,14 @@ public class ConfigAccessor {
 		configFile = new File(folderPath + File.separator + fileName);
 	}
 
-	@SuppressWarnings("deprecation")
 	public void reloadConfig() {
 		fileConfiguration = YamlConfiguration.loadConfiguration(configFile);
 
 		// Look for defaults in the jar
 		InputStream defConfigStream = plugin.getResource(fileName);
 		if (defConfigStream != null) {
-			YamlConfiguration defConfig = YamlConfiguration.loadConfiguration(defConfigStream);
+			Reader defConfigReader = new InputStreamReader(defConfigStream);
+			YamlConfiguration defConfig = YamlConfiguration.loadConfiguration(defConfigReader);
 			fileConfiguration.setDefaults(defConfig);
 			try {
 				//fileConfiguration.save(configFile);


### PR DESCRIPTION
`YamlConfiguration.loadConfiguration(InputStream)` is deprecated.

This fix makes VR work fine for me on my 1.12 server.

Fixes https://dev.bukkit.org/projects/voteroulette/issues/177

EDIT: For anyone who finds it helpful, my compiled .jar which includes this fix, working well for me on our 1.12 server is at http://www.preshweb.co.uk/downloads/VoteRoulette-3.2.3-bigpresh.jar - but of course, as I'm not part of the project, you shouldn't really trust it, you should build it yourself from source or wait from an "official" build to be released - but, it's there as an option for anyone who wants it.  (Also, ebiggz, if you'd rather I pull that, just let me know and I'll take it down.)