### PR TITLE
Support 1.14.x

### DIFF
--- a/src/com/mythicacraft/voteroulette/VoteRoulette.java
+++ b/src/com/mythicacraft/voteroulette/VoteRoulette.java
@@ -726,7 +726,7 @@ public class VoteRoulette extends JavaPlugin {
 
 		PLAYER_AWARDS_SUMMARY_MESSAGE = Utils.transcribeColorCodes(messageData.getConfig().getString("player-awards-summary-message", "&bYou have received the %type% &e%names% &bwhich gave you, combined:&e %prizes%"));
 
-		PERIODIC_REMINDER = Utils.transcribeColorCodes(messageData.getConfig().getString("periodic-reminder").replace("%server%", Bukkit.getServerName()));
+		PERIODIC_REMINDER = Utils.transcribeColorCodes(messageData.getConfig().getString("periodic-reminder").replace("%server%", Bukkit.getServer().getName()));
 
 		TWENTYFOUR_REMINDER = Utils.transcribeColorCodes(messageData.getConfig().getString("twentyfour-hour-reminder", "&b24 hours have passed since your last vote!"));
 

--- a/src/com/mythicacraft/voteroulette/api/PlayerEarnedAwardEvent.java
+++ b/src/com/mythicacraft/voteroulette/api/PlayerEarnedAwardEvent.java
@@ -14,6 +14,7 @@ public class PlayerEarnedAwardEvent extends Event {
 	private boolean cancelled;
 
 	public PlayerEarnedAwardEvent(String playerName, Award award) {
+		super(true); // make event async
 		this.playerName = playerName;
 		this.award = award;
 	}

--- a/src/com/mythicacraft/voteroulette/listeners/VoteProcessor.java
+++ b/src/com/mythicacraft/voteroulette/listeners/VoteProcessor.java
@@ -67,10 +67,10 @@ public class VoteProcessor implements Runnable {
 		VoteRoulette.getStatsManager().updateStatsWithPlayer(playerName);
 
 		String voteMessage = plugin.SERVER_BROADCAST_MESSAGE_NO_AWARD;
-		voteMessage = voteMessage.replace("%player%", playerName).replace("%server%", Bukkit.getServerName()).replace("%site%", website);
+		voteMessage = voteMessage.replace("%player%", playerName).replace("%server%", Bukkit.getServer().getName()).replace("%site%", website);
 
 		String playerVoteMessage = plugin.PLAYER_VOTE_MESSAGE_NO_AWARD;
-		playerVoteMessage = playerVoteMessage.replace("%player%", playerName).replace("%server%", Bukkit.getServerName()).replace("%site%", website);
+		playerVoteMessage = playerVoteMessage.replace("%player%", playerName).replace("%server%", Bukkit.getServer().getName()).replace("%site%", website);
 
 		// First check if player is blacklisted & check if the blacklist is
 		// being used as a white list
@@ -220,11 +220,11 @@ public class VoteProcessor implements Runnable {
 
 		if (!website.equals("forcevote")) {
 			String voteMessage = plugin.SERVER_BROADCAST_MESSAGE_NO_AWARD;
-			voteMessage = voteMessage.replace("%player%", playerName).replace("%server%", Bukkit.getServerName()).replace("%site%", website);
+			voteMessage = voteMessage.replace("%player%", playerName).replace("%server%", Bukkit.getServer().getName()).replace("%site%", website);
 			Utils.broadcastMessageToServer(voteMessage, playerName);
 
 			String playerVoteMessage = plugin.PLAYER_VOTE_MESSAGE_NO_AWARD;
-			playerVoteMessage = playerVoteMessage.replace("%player%", playerName).replace("%server%", Bukkit.getServerName()).replace("%site%", website);
+			playerVoteMessage = playerVoteMessage.replace("%player%", playerName).replace("%server%", Bukkit.getServer().getName()).replace("%site%", website);
 			String currentCycle = Integer.toString(voter.getCurrentVoteCycle());
 			Utils.sendMessageToPlayer(playerVoteMessage.replace("%cycle%", currentCycle), playerName);
 		}
@@ -287,7 +287,7 @@ public class VoteProcessor implements Runnable {
 		}
 		if (!website.equals("forcevote")) {
 			String voteMessage = plugin.SERVER_BROADCAST_MESSAGE_NO_AWARD;
-			voteMessage = voteMessage.replace("%player%", playerName).replace("%server%", Bukkit.getServerName()).replace("%site%", website);
+			voteMessage = voteMessage.replace("%player%", playerName).replace("%server%", Bukkit.getServer().getName()).replace("%site%", website);
 			Utils.broadcastMessageToServer(voteMessage, playerName);
 		}
 	}

--- a/src/com/mythicacraft/voteroulette/utils/Utils.java
+++ b/src/com/mythicacraft/voteroulette/utils/Utils.java
@@ -461,7 +461,7 @@ public class Utils {
 			Award award, Voter voter) {
 		awardMessage = awardMessage.replace("%name%", award.getName());
 		awardMessage = awardMessage.replace("%player%", voter.getPlayerName());
-		awardMessage = awardMessage.replace("%server%", Bukkit.getServerName());
+		awardMessage = awardMessage.replace("%server%", Bukkit.getServer().getName());
 
 		if (award.getAwardType() == AwardType.MILESTONE) {
 			awardMessage = awardMessage.replace("%type%", plugin.MILESTONE_DEF.toLowerCase());
@@ -477,7 +477,7 @@ public class Utils {
 		if (!award.hasMessage()) {
 			awardMessage = awardMessage.replace("%name%", award.getName());
 			awardMessage = awardMessage.replace("%player%", voter.getPlayerName());
-			awardMessage = awardMessage.replace("%server%", Bukkit.getServerName());
+			awardMessage = awardMessage.replace("%server%", Bukkit.getServer().getName());
 
 			if (award.getAwardType() == AwardType.MILESTONE) {
 				awardMessage = awardMessage.replace("%type%", plugin.MILESTONE_DEF.toLowerCase());
@@ -540,7 +540,7 @@ public class Utils {
 		String awardsListStr = sb.toString();
 		String summerizeMessage = plugin.PLAYER_AWARDS_SUMMARY_MESSAGE;
 
-		summerizeMessage = summerizeMessage.replace("%names%", awardsListStr).replace("%player%", voter.getPlayerName()).replace("%server%", Bukkit.getServerName()).replace("%prizes%", getSummarizedAwardPrizesString(awards, voter));
+		summerizeMessage = summerizeMessage.replace("%names%", awardsListStr).replace("%player%", voter.getPlayerName()).replace("%server%", Bukkit.getServer().getName()).replace("%prizes%", getSummarizedAwardPrizesString(awards, voter));
 
 		if (awards.get(0) instanceof Milestone) {
 			if (awards.size() > 1) {


### PR DESCRIPTION
Votifier wasn't working for me in 1.14.x.

First, I got errors calling `org.bukkit.Bukkit.getServerName()` so I've changed all those calls from `Bukkit.getServerName()` to `Bukkit.getServer().getName()`.

After that, I got:

```
[18:08:40] [Thread-31/WARN]: Exception in thread "Thread-31" java.lang.IllegalStateException: PlayerEarnedAwardEvent may only be triggered synchronously.
[18:08:40] [Thread-31/WARN]:    at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:533)
[18:08:40] [Thread-31/WARN]:    at com.mythicacraft.voteroulette.utils.Utils.playerEarnAward(Utils.java:173)
[18:08:40] [Thread-31/WARN]:    at com.mythicacraft.voteroulette.listeners.VoteProcessor.giveRandomReward(VoteProcessor.java:208)
[18:08:40] [Thread-31/WARN]:    at com.mythicacraft.voteroulette.listeners.VoteProcessor.run(VoteProcessor.java:149)
[18:08:40] [Thread-31/WARN]:    at java.lang.Thread.run(Thread.java:748)
```

With the changes in this PR, VoteRoulette is now working again for me in 1.14.4 (running `Paper git-Paper-163 (MC: 1.14.4)`)

For convenience, the build that I'm running on my server is available to download: http://www.preshweb.co.uk/downloads/VoteRoulette-3.2.3-bigpresh-114-fix.jar

Of course, as I'm not the author and that's not an official release, it's up to you whether you wish to trust me enough to use it; otherwise, you should either build it yourself, or wait for an official 1.14-compatible VoteRoulette release. 